### PR TITLE
Pass the completion callback as the first argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@
  */
 module.exports = function emits() {
   var self = this
-    , length
     , parser;
 
   for (var i = 0, l = arguments.length, args = new Array(l); i < l; i++) {
@@ -17,8 +16,7 @@ module.exports = function emits() {
   }
 
   //
-  // Assume that if the last given argument is a function, it would be
-  // a parser.
+  // If the last argument is a function, assume that it's a parser.
   //
   if ('function' !== typeof args[args.length - 1]) return function emitter() {
     for (var i = 0, l = arguments.length, arg = new Array(l); i < l; i++) {
@@ -29,18 +27,17 @@ module.exports = function emits() {
   };
 
   parser = args.pop();
-  length = parser.length;
 
   /**
-   * The actual function does the emitting of the given event. It will return
-   * a boolean indicating if the event was emitted.
+   * The actual function that emits the given event. It returns a boolean
+   * indicating if the event was emitted.
    *
    * @returns {Boolean}
    * @api public
    */
   return function emitter() {
-    for (var i = 0, arg = new Array(length); i < length; i++) {
-      arg[i] = arguments[i];
+    for (var i = 0, l = arguments.length, arg = new Array(l + 1); i < l; i++) {
+      arg[i + 1] = arguments[i];
     }
 
     /**
@@ -50,13 +47,14 @@ module.exports = function emits() {
      * @param {Mixed} returned
      * @api private
      */
-    arg[length - 1] = function next(err, returned) {
+    arg[0] = function next(err, returned) {
       if (err) return self.emit('error', err);
 
       if (arguments.length < 2) return false;
-      if (returned === null) arg = [];
-      else if (returned !== undefined) arg = returned;
-      else arg = arg.slice(0, length - 1);
+
+      arg = returned === undefined
+        ? arg.slice(1) : returned === null
+          ? [] : returned;
 
       self.emit.apply(self, args.concat(arg));
     };

--- a/test.js
+++ b/test.js
@@ -60,7 +60,8 @@ describe('emits', function () {
   });
 
   it('calls the parser function even when there are no listeners', function (next) {
-    var fn = example.emits('data', function () {
+    var fn = example.emits('data', function (done) {
+      done();
       next();
     });
 
@@ -68,7 +69,7 @@ describe('emits', function () {
   });
 
   it('does not emit the event if no data argument is supplied', function (next) {
-    var fn = example.emits('data', function parser(done) {
+    var fn = example.emits('data', function (done) {
       done();
       next();
     });
@@ -96,15 +97,15 @@ describe('emits', function () {
   });
 
   it('returns all received arguments when undefined is returned', function (next) {
-    var fn = example.emits('data', 'sup', function (foo, bar, done) {
+    var fn = example.emits('data', 'sup', function (done) {
       done(undefined, undefined);
     });
 
     example.on('data', function (sup, foo, bar) {
-      assume('sup').equals(sup);
-      assume(bar).equals('bar');
-      assume(foo).equals('foo');
       assume(arguments).has.length(3);
+      assume(sup).equals('sup');
+      assume(foo).equals('foo');
+      assume(bar).equals('bar');
 
       next();
     });
@@ -113,7 +114,7 @@ describe('emits', function () {
   });
 
   it('can modify the data', function (next) {
-    var fn = example.emits('data', 'sup', function (data, done) {
+    var fn = example.emits('data', 'sup', function (done) {
       done(undefined, 'bar');
     });
 
@@ -127,14 +128,15 @@ describe('emits', function () {
     assume(fn('foo')).is.true();
   });
 
-  it('supports async execution based on the amount of args', function (next) {
-    var fn = example.emits('data', 'sup', function (data, fn) {
+  it('supports async execution', function (next) {
+    var fn = example.emits('data', 'sup', function (done) {
       setTimeout(function () {
-        fn(undefined, 'bar');
+        done(undefined, 'bar');
       }, 100);
     });
 
     example.on('data', function (sup, foo, bar) {
+      assume(bar).equals(undefined);
       assume(sup).equals('sup');
       assume(foo).equals('bar');
 
@@ -145,13 +147,13 @@ describe('emits', function () {
   });
 
   it('emits an error when async execution fails with an error', function (next) {
-    var fn = example.emits('data', 'sup', function (data, fn) {
+    var fn = example.emits('data', 'sup', function (done) {
       setTimeout(function () {
-        fn(new Error('lol failure'), 'bar');
+        done(new Error('lol failure'), 'bar');
       }, 100);
     });
 
-    example.on('data', function (sup, foo, bar) {
+    example.on('data', function () {
       throw new Error('I should never be called');
     });
 


### PR DESCRIPTION
This goes against the convention of having the callback as the last argument but it makes the module more flexible.

For example:

``` js
var emits = example.emits('data', 'foo', function (done) {
  if (arguments.length < 3) return done(new Error('this should not happen'));
  done(undefined, undefined);
});

emits('bar', 'baz');
emits('bar');
```
